### PR TITLE
Cell value get - stack overflow exception

### DIFF
--- a/ClosedXML/Excel/Cells/IXLCell.cs
+++ b/ClosedXML/Excel/Cells/IXLCell.cs
@@ -30,6 +30,16 @@ namespace ClosedXML.Excel
         /// </value>
         Object Value { get; set; }
 
+        /// <summary>
+        /// Gets the cell's value. See <see cref="IXLCell.Value"/> (get) for more informations.
+        /// <para>ClosedXML will limit maximum recursive calls.</para>
+        /// <para>>An exception will be thrown when the limit is exceeded.</para>
+        /// </summary>
+        /// <param name="maximumRecursiveDepth">Recursive call limit</param>
+        /// <param name="resursiveCallCounter">Actual recursive call count</param>
+        /// <exception cref="StackOverflowException"></exception>
+        Object GetValue(int maximumRecursiveDepth, int resursiveCallCounter = 0);
+
         /// <summary>Gets this cell's address, relative to the worksheet.</summary>
         /// <value>The cell's address.</value>
         IXLAddress Address { get; }

--- a/ClosedXML/Excel/Cells/XLCell.cs
+++ b/ClosedXML/Excel/Cells/XLCell.cs
@@ -356,71 +356,7 @@ namespace ClosedXML.Excel
         {
             get
             {
-                var fA1 = FormulaA1;
-                if (!String.IsNullOrWhiteSpace(fA1))
-                {
-                    if (fA1[0] == '{')
-                        fA1 = fA1.Substring(1, fA1.Length - 2);
-
-                    string sName;
-                    string cAddress;
-                    if (fA1.Contains('!'))
-                    {
-                        sName = fA1.Substring(0, fA1.IndexOf('!'));
-                        if (sName[0] == '\'')
-                            sName = sName.Substring(1, sName.Length - 2);
-
-                        cAddress = fA1.Substring(fA1.IndexOf('!') + 1);
-                    }
-                    else
-                    {
-                        sName = Worksheet.Name;
-                        cAddress = fA1;
-                    }
-
-                    if (_worksheet.Workbook.WorksheetsInternal.Any<XLWorksheet>(
-                        w => String.Compare(w.Name, sName, true) == 0)
-                        && XLHelper.IsValidA1Address(cAddress)
-                        )
-                        return _worksheet.Workbook.Worksheet(sName).Cell(cAddress).Value;
-
-                    var retVal = Worksheet.Evaluate(fA1);
-                    var retValEnumerable = retVal as IEnumerable;
-
-                    if (retValEnumerable != null && !(retVal is String))
-                        return retValEnumerable.Cast<object>().First();
-
-                    return retVal;
-                }
-
-                var cellValue = HasRichText ? _richText.ToString() : _cellValue;
-
-                if (_dataType == XLDataType.Boolean)
-                    return cellValue != "0";
-
-                if (_dataType == XLDataType.DateTime)
-                {
-                    Double d;
-                    if (Double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out d)
-                        && d.IsValidOADateNumber())
-                        return DateTime.FromOADate(d);
-                }
-
-                if (_dataType == XLDataType.Number)
-                {
-                    Double d;
-                    if (double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out d))
-                        return d;
-                }
-
-                if (_dataType == XLDataType.TimeSpan)
-                {
-                    TimeSpan t;
-                    if (TimeSpan.TryParse(cellValue, out t))
-                        return t;
-                }
-
-                return cellValue;
+                return GetValue();
             }
 
             set
@@ -446,6 +382,75 @@ namespace ClosedXML.Excel
 
                 if (_cellValue.Length > 32767) throw new ArgumentException("Cells can hold only 32,767 characters.");
             }
+        }
+
+        private object GetValue()
+        {
+            var fA1 = FormulaA1;
+            if (!String.IsNullOrWhiteSpace(fA1))
+            {
+                if (fA1[0] == '{')
+                    fA1 = fA1.Substring(1, fA1.Length - 2);
+
+                string sName;
+                string cAddress;
+                if (fA1.Contains('!'))
+                {
+                    sName = fA1.Substring(0, fA1.IndexOf('!'));
+                    if (sName[0] == '\'')
+                        sName = sName.Substring(1, sName.Length - 2);
+
+                    cAddress = fA1.Substring(fA1.IndexOf('!') + 1);
+                }
+                else
+                {
+                    sName = Worksheet.Name;
+                    cAddress = fA1;
+                }
+
+                if (_worksheet.Workbook.WorksheetsInternal.Any<XLWorksheet>(
+                    w => String.Compare(w.Name, sName, true) == 0)
+                    && XLHelper.IsValidA1Address(cAddress)
+                    )
+                    return _worksheet.Workbook.Worksheet(sName).Cell(cAddress).Value;
+
+                var retVal = Worksheet.Evaluate(fA1);
+                var retValEnumerable = retVal as IEnumerable;
+
+                if (retValEnumerable != null && !(retVal is String))
+                    return retValEnumerable.Cast<object>().First();
+
+                return retVal;
+            }
+
+            var cellValue = HasRichText ? _richText.ToString() : _cellValue;
+
+            if (_dataType == XLDataType.Boolean)
+                return cellValue != "0";
+
+            if (_dataType == XLDataType.DateTime)
+            {
+                Double d;
+                if (Double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out d)
+                    && d.IsValidOADateNumber())
+                    return DateTime.FromOADate(d);
+            }
+
+            if (_dataType == XLDataType.Number)
+            {
+                Double d;
+                if (double.TryParse(cellValue, XLHelper.NumberStyle, XLHelper.ParseCulture, out d))
+                    return d;
+            }
+
+            if (_dataType == XLDataType.TimeSpan)
+            {
+                TimeSpan t;
+                if (TimeSpan.TryParse(cellValue, out t))
+                    return t;
+            }
+
+            return cellValue;
         }
 
         public IXLTable InsertTable<T>(IEnumerable<T> data)

--- a/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
+++ b/ClosedXML_Tests/Excel/Cells/XLCellTests.cs
@@ -345,6 +345,46 @@ namespace ClosedXML_Tests
         }
 
         [Test]
+        public void GetValue_MaximumRecursionDepthExceeded()
+        {
+            Assert.Throws<StackOverflowException>(() =>
+            {
+                IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+                IXLCell cell = ws.Cell(1, 1);
+                cell.FormulaA1 = "A1";
+                cell.GetValue(maximumRecursiveDepth: 1000);
+            });
+        }
+
+        [Test]
+        public void GetValue_MaximumRecursionDepthExceeded2()
+        {
+            Assert.Throws<StackOverflowException>(() =>
+            {
+                IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+                IXLCell firstCell = ws.Cell(1, 1);
+                firstCell.FormulaA1 = "B1";
+                ws.Cell(1, 2).FormulaA1 = "C1";
+                ws.Cell(1, 3).Value = 5;
+
+                var actualValue = firstCell.GetValue(maximumRecursiveDepth: 1);
+            });
+        }
+
+        [Test]
+        public void GetValue_MaximumRecursionDepthNotExceeded()
+        {
+            IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");
+            IXLCell firstCell = ws.Cell(1, 1);
+            firstCell.FormulaA1 = "B1";
+            ws.Cell(1, 2).FormulaA1 = "C1";
+            ws.Cell(1, 3).Value = 5;
+
+            var actualValue = firstCell.GetValue(maximumRecursiveDepth: 2);
+            Assert.AreEqual(5, actualValue);
+        }
+
+        [Test]
         public void ValueSetToEmptyString()
         {
             IXLWorksheet ws = new XLWorkbook().Worksheets.Add("Sheet1");


### PR DESCRIPTION
#### What's this PR do?
Prevent throwing _uncatchable_ StackOverflowException when trying get value of cell with circular referenced formula.
This PR proposes counting the depth of recursion and throwing _catchable_ exception when depth limit will be exceeded.
#### Where should the reviewer start?
See new unit tests, check changes in IXLCell interface, rest of code.
PS, first commit is only refactor (extract method), second contains logic changes.
#### How should this be manually tested?
Create file with circular referenced cells, try read value of cell, run new unit tests.
#### Any background context you want to provide?
32767 value is from [Excel specifications and limits](https://support.office.com/en-us/article/Excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3) (_Feature: Iterations_).

I am not sure if the solution proposed by me is a good idea. Maybe an circular reference detection algorithm is a better idea?
#### Screenshots (if appropriate)
#### Questions:
- Is there a blog post? No
- Does the knowledge base need an update? Yes(?). I changed interface, but this is non breaking change (new method). Also 'XLCell.Value' behavior has changed.
- Does this add new (C#) dependencies? No

- [ ] C# Code Review: @csreviewer
- [ ] Test Automation Review: @csreviewer